### PR TITLE
Replacing deprecated "file_create_url()" function

### DIFF
--- a/modules/custom/wxt_core/src/Plugin/Field/FieldFormatter/Lightbox.php
+++ b/modules/custom/wxt_core/src/Plugin/Field/FieldFormatter/Lightbox.php
@@ -106,7 +106,7 @@ class Lightbox extends ImageFormatterBase {
           'title' => $title,
         ],
       ];
-      $url = Url::fromUri(file_create_url($lbx_image_path), $url_options);
+      $url = Url::fromUri(\Drupal::service('file_url_generator')->generateAbsoluteString($lbx_image_path), $url_options);
 
       $item_attributes['class'][] = 'thumbnail';
 


### PR DESCRIPTION
Since this is now deprecated in Drupal 10, the function should be replaced with: 

\Drupal::service('file_url_generator')->generateAbsoluteString()